### PR TITLE
Ispravak modela primatelja i iznosa bez zareza u generiranom kodu

### DIFF
--- a/docs/script/lib/BarcodePayment.js
+++ b/docs/script/lib/BarcodePayment.js
@@ -20,7 +20,14 @@
 	
 	const EncodePrice = function(price) {
 		var fullLength = 15;
-		return PadLeft(price.replace(',', ''), fullLength, '0');
+
+		if(price.includes(',')) {
+			return PadLeft(price.replace(',', ''), fullLength, '0');
+		}
+		else {
+			price = price.concat(",00"); //Workaround for price without decimals.
+			return PadLeft(price.replace(',', ''), fullLength, '0');
+		}
 	}
 	
 	const ConcatenateStrings = function() {
@@ -46,7 +53,7 @@
 	const _delimiter = String.fromCharCode(0x0A);
 	const _header = "HRVHUB30";
 	const _currency = "HRK"
-	const _paymentModelPrefix = "HR";
+	const _paymentModelPrefix = "";
 
 	let _settings ={
 		ValidateIBAN: false, // TODO: Implement IBAN validation


### PR DESCRIPTION
Prijedlog ispravka greške br. https://github.com/knee-cola/generator-opce-uplatnice/issues/1
Rješava problem sa dvostrukim modelom primatelja (https://github.com/knee-cola/generator-opce-uplatnice/issues/1#issue-598435236)
Također predlažem workaround za (https://github.com/knee-cola/generator-opce-uplatnice/issues/1#issuecomment-618224710). Ovo tehnički nije bug, ali ako zaboravim staviti ",00" na cjelobrojni iznos, dobijem krivi iznos u 2D kodu koji se tek primjeti kod plaćanja.
